### PR TITLE
Update CI to use LTS version of software

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
+          - 'lts'
           - '1'
         os:
           - ubuntu-latest


### PR DESCRIPTION
Ref https://github.com/tensor4all/QuanticsGrids.jl/pull/9#issue-2575530963 and https://github.com/tensor4all/TensorCrossInterpolation.jl/pull/45